### PR TITLE
Hide incompatible GPU

### DIFF
--- a/EFI/OC/config.plist
+++ b/EFI/OC/config.plist
@@ -224,6 +224,15 @@
 				AgAAAA==
 				</data>
 			</dict>
+			<key>PciRoot(0x0)/Pci(0x1,0x1)/Pci(0x0,0x0)</key>
+			<dict>
+				<key>name</key>
+				<data>I2Rpc3BsYXk=</data>
+				<key>IOName</key>
+				<string>#display</string>
+				<key>class-code</key>
+				<data>/////w==</data>
+			</dict>			
 		</dict>
 		<key>Delete</key>
 		<dict>


### PR DESCRIPTION
This PR hides my incompatible GPU — RTX 3080.
I'm not certain but I believe this is the reason for some nightly crashes I've been experiencing.

# Before

![Screen Shot 2021-11-07 at 8 33 10 AM](https://user-images.githubusercontent.com/860596/140647407-9ef9d0cb-1704-419e-9ae2-8a18f60d701d.png)
# After

![Screen Shot 2021-11-07 at 8 35 34 AM](https://user-images.githubusercontent.com/860596/140647411-ef8b18e6-7b9f-423b-9a26-9cb01d7ad3ac.png)

# Kernel panic log
```
panic(cpu 3 caller 0xffffff800f6d8b86): Wake transition timed out after 180 seconds while calling power state change callbacks. Suspected bundle: com.apple.iokit.IOGraphicsFamily. Thread 0xfb85.
Failure code:: 0x00000001 00000027

Backtracing specified thread
Panicked task 0xffffff8553dba6a0: 243 threads: pid 0: kernel_task
Backtrace (CPU 3), panicked thread: 0xffffff855821a000, Frame : Return Address
0xffffffe0cf05b818 : 0xffffff800efdf9db mach_kernel : _machine_switch_context + 0xdb
0xffffffe0cc95bb80 : 0xffffff800eec6918 mach_kernel : _thread_unstop + 0x1fe8
0xffffffe0cc95bbf0 : 0xffffff800eec4887 mach_kernel : _thread_block_reason + 0xc7
0xffffffe0cc95bc40 : 0xffffff800efdc980 mach_kernel : _lck_mtx_lock_wait_x86 + 0x120
0xffffffe0cc95bc80 : 0xffffff800efdc1fb mach_kernel : _lck_mtx_lock_slow + 0x1cb
0xffffffe0cc95bcb0 : 0xffffff7fa735dfc7 com.apple.iokit.IOGraphicsFamily : __ZN18IOGraphicsWorkLoop9closeGateEv + 0x27
0xffffffe0cc95bce0 : 0xffffff7fa737804d com.apple.iokit.IOGraphicsFamily : __ZN28IOGraphicsControllerWorkLoop9closeGateEv + 0x9
0xffffffe0cc95bcf0 : 0xffffff7fa736111f com.apple.iokit.IOGraphicsFamily : __ZN18IOGraphicsWorkLoop14timedCloseGateEPKcS1_ + 0x49
0xffffffe0cc95bd80 : 0xffffff7fa736dbe9 com.apple.iokit.IOGraphicsFamily : __ZN13IOFramebuffer21powerStateDidChangeToEmmP9IOService + 0x37
0xffffffe0cc95bdb0 : 0xffffff800f63fda7 mach_kernel : __ZN9IOService23driverInformPowerChangeEv + 0x157
0xffffffe0cc95be50 : 0xffffff800f63f7d4 mach_kernel : __ZN9IOService15pmDriverCalloutEPS_ + 0x34
0xffffffe0cc95be70 : 0xffffff800eeecc85 mach_kernel : _thread_call_delayed_timer + 0x4f5
0xffffffe0cc95bee0 : 0xffffff800eeedcd2 mach_kernel : _thread_call_delayed_timer + 0x1542
0xffffffe0cc95bfa0 : 0xffffff800ee3b18e mach_kernel : _call_continuation + 0x2e
      Kernel Extensions in backtrace:
         com.apple.iokit.IOGraphicsFamily(593.0)[D7EBF011-CEEF-3DF8-BD85-6CCE427455B7]@0xffffff7fa7354000->0xffffff7fa7382fff
            dependency: com.apple.iokit.IOPCIFamily(2.9)[5E1B0BE0-4B73-35F5-9126-EB05FBB8BAF5]@0xffffff80119ee000->0xffffff8011a18fff

Process name corresponding to current thread (0xffffff855821a000): kernel_task
Boot args: keepsyms=1 chunklist-security-epoch=0 -chunklist-no-rev2-dev

Mac OS version:
21A559

Kernel version:
Darwin Kernel Version 21.1.0: Wed Oct 13 17:33:23 PDT 2021; root:xnu-8019.41.5~1/RELEASE_X86_64
Kernel UUID: 19BD4E1B-0268-3EE0-BC66-91F035BC9429
KernelCache slide: 0x000000000ec00000
KernelCache base:  0xffffff800ee00000
Kernel slide:      0x000000000ec10000
Kernel text base:  0xffffff800ee10000
__HIB  text base: 0xffffff800ed00000
System model name: iMac19,1 (Mac-AA95B1DDAB278B95)
System shutdown begun: NO
Panic diags file available: YES (0x0)
Hibernation exit count: 0

System uptime in nanoseconds: 10695282775171
Last Sleep:           absolute           base_tsc          base_nano
  Uptime  : 0x000009ba3087d673
  Sleep   : 0x0000097bbff8f1af 0x0000001ea6b1e630 0x0000000000000000
  Wake    : 0x0000097c19524b89 0x000000011d55942a 0x0000097c0b3b012c
Zone info:
Foreign   : 0xffffff80144d8000 - 0xffffff80144e5000
Native    : 0xffffff8046504000 - 0xffffffa046504000
Readonly  : 0 - 0
Metadata  : 0xffffffe4a9742000 - 0xffffffe4c9a63000
Bitmaps   : 0xffffffe4c9a63000 - 0xffffffe4d5a63000
```

See https://dortania.github.io/OpenCore-Install-Guide/extras/spoof.html